### PR TITLE
Update to Elixir 0.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ otp_release:
   - 17.0
 before_install:
   - mkdir -p vendor/elixir
-  - wget -q https://github.com/elixir-lang/elixir/releases/download/v0.13.3/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
+  - wget -q https://github.com/elixir-lang/elixir/releases/download/v0.14.1/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
   - export PATH="$PATH:$PWD/vendor/elixir/bin"
 script: "MIX_ENV=test mix do deps.get, test"

--- a/lib/http_server.ex
+++ b/lib/http_server.ex
@@ -1,5 +1,5 @@
 defmodule HttpServer do
-  use Application.Behaviour
+  use Application
 
   def start, do: start([], [])
   def start(args), do: start([], args)

--- a/lib/http_server/supervisor.ex
+++ b/lib/http_server/supervisor.ex
@@ -1,6 +1,6 @@
 # TODO
 defmodule HttpServer.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def start_link do
     :supervisor.start_link(__MODULE__, [])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HttpServer.Mixfile do
   def project do
     [ app: :http_server,
       version: "0.0.1",
-      elixir: "~> 0.13.0",
+      elixir: "~> 0.14.1",
       deps: deps(Mix.env)
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"cowboy": {:git, "git://github.com/extend/cowboy.git", "6672ea04155a075e60381413bf9b65b3974b7d57", [tag: "0.9.0"]},
   "cowlib": {:git, "git://github.com/extend/cowlib.git", "34a39ef28ca841fb9233ce9df3ec654eb321c5e5", [ref: "0.3.0"]},
-  "httpotion": {:git, "git://github.com/myfreeweb/httpotion.git", "346d9c775c628dbd21657bd232a28b7cf718e6e5", []},
+  "httpotion": {:git, "git://github.com/myfreeweb/httpotion.git", "c20be2e821c08e607b9c0247c83e909d178ee6c0", []},
   "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "7871e2ebe8811efb64e1917e2de455fa87e8dfe3", [tag: "v4.1.0"]},
   "ranch": {:git, "git://github.com/extend/ranch.git", "41705752ffc7e3ecb96eef8374015ead4ca7f699", [ref: "0.8.5"]}}


### PR DESCRIPTION
Update http_server to Elixir 0.14.1
- Remove deprecated code
- Update HTTPotion

This update is necessary to update exvcr
