### PR TITLE
Fully custom response

### DIFF
--- a/lib/http_server/handler.ex
+++ b/lib/http_server/handler.ex
@@ -23,7 +23,12 @@ defmodule HttpServer.Handler do
   def handle(req, state) do
     {response, wait_time} = :ets.lookup(@ets_table, @ets_key)[@ets_key]
     wait_for(wait_time)
-    {:ok, req} = :cowboy_req.reply 200, [], response, req
+    case response do
+      {status, headers, body} ->
+        {:ok, req} = :cowboy_req.reply status, headers, body, req
+      body ->
+        {:ok, req} = :cowboy_req.reply 200, [], body, req
+    end
     {:ok, req, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule HttpServer.Mixfile do
 
   def project do
     [ app: :http_server,
-      version: "0.0.1",
+      version: "0.0.2",
       elixir: "~> 0.14.1 or ~> 0.15.0 or ~> 1.0 or ~> 1.1",
       deps: deps(Mix.env)
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HttpServer.Mixfile do
   def project do
     [ app: :http_server,
       version: "0.0.1",
-      elixir: "~> 0.14.1 or ~> 0.15.0 or ~> 1.0",
+      elixir: "~> 0.14.1 or ~> 0.15.0 or ~> 1.0 or ~> 1.1",
       deps: deps(Mix.env)
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"cowboy": {:package, "1.0.0"},
-  "cowlib": {:package, "1.0.0"},
-  "httpotion": {:git, "git://github.com/myfreeweb/httpotion.git", "1419c64468483d192cc017f18de3412f9dca7fb4", []},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "7871e2ebe8811efb64e1917e2de455fa87e8dfe3", [tag: "v4.1.0"]},
-  "ranch": {:package, "1.0.0"}}
+%{"cowboy": {:hex, :cowboy, "1.0.4"},
+  "cowlib": {:hex, :cowlib, "1.0.2"},
+  "httpotion": {:git, "https://github.com/myfreeweb/httpotion.git", "1419c64468483d192cc017f18de3412f9dca7fb4", []},
+  "ibrowse": {:git, "https://github.com/cmullaparthi/ibrowse.git", "7871e2ebe8811efb64e1917e2de455fa87e8dfe3", [tag: "v4.1.0"]},
+  "ranch": {:hex, :ranch, "1.2.0"}}

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -31,4 +31,17 @@ defmodule HttpServerTest do
     assert(:timer.now_diff(e, s) >= 800_000)  # 0.8 sec
     HttpServer.stop(4001)
   end
+
+  test "custom status code and headers" do
+    HttpServer.start(
+      path: "/test",
+      port: 4000,
+      response: {201, [{"X-Custom", "My-Header"}], "Created"}
+    )
+
+    response = HTTPotion.get("http://localhost:4000/test")
+    assert(response.body == "Created")
+    assert(response.status_code == 201)
+    assert(response.headers[:"X-Custom"] == "My-Header")
+  end
 end


### PR DESCRIPTION
In my tests, behavior can differ based on the response status and headers, so I needed a way to fully stub that out. This PR lets you set the response as a `{status, headers, body}` tuple, and will reply with those exact values.

Side note: I'm running on Elixir 1.1.1 and it forced me to update the mix.lock file so I could run tests. Not sure if that's a big deal or not.