### PR TITLE
Support for function that returns response based on request.

### DIFF
--- a/lib/http_server/handler.ex
+++ b/lib/http_server/handler.ex
@@ -61,6 +61,10 @@ defmodule HttpServer.Handler do
     {port, _} = :cowboy_req.port(req)
     {method, _} = :cowboy_req.method(req)
 
+    headers = Enum.map(headers, fn({k, v}) -> {String.to_atom(k), v} end)
+    query_params = Enum.map(query_params, fn({k, v}) -> {String.to_atom(k), v} end)
+    post_params = Enum.map(post_params, fn({k, v}) -> {String.to_atom(k), v} end)
+
     %{
       method: method,
       host: host,

--- a/lib/http_server/handler.ex
+++ b/lib/http_server/handler.ex
@@ -26,8 +26,13 @@ defmodule HttpServer.Handler do
     case response do
       {status, headers, body} ->
         {:ok, req} = :cowboy_req.reply status, headers, body, req
-      body ->
-        {:ok, req} = :cowboy_req.reply 200, [], body, req
+      response ->
+        if is_function(response) do
+          {status, headers, body} = response.(req_values(req))
+          {:ok, req} = :cowboy_req.reply status, headers, body, req
+        else
+          {:ok, req} = :cowboy_req.reply 200, [], response, req
+        end
     end
     {:ok, req, state}
   end
@@ -44,6 +49,28 @@ defmodule HttpServer.Handler do
         :completed -> nil  # do nothing
       end
     end
+  end
+
+  # Parse the cowboy request into something that's easy to pull values out of.
+  defp req_values(req) do
+    {headers, _} = :cowboy_req.headers(req)
+    {query_params, _} = :cowboy_req.qs_vals(req)
+    {:ok, body, _} = :cowboy_req.body(req)
+    {host, _} = :cowboy_req.host(req)
+    {:ok, post_params, _} = :cowboy_req.body_qs(req)
+    {port, _} = :cowboy_req.port(req)
+    {method, _} = :cowboy_req.method(req)
+
+    %{
+      method: method,
+      host: host,
+      port: port,
+      headers: headers,
+      query_params: query_params,
+      post_params: post_params,
+      body: body,
+      req: req
+    }
   end
 
   def terminate(_reason, _request, _state) do

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -50,11 +50,11 @@ defmodule HttpServerTest do
       path: "/test",
       port: 4000,
       response: fn(req) ->
-        assert req.headers["x-test-header"] == "My-Value"
+        assert req.headers[:"x-test-header"] == "My-Value"
         assert req.host == "localhost"
-        assert req.query_params["foo"] == "bar"
-        assert req.query_params["abc"] == "def"
-        assert req.post_params["body"] == "param"
+        assert req.query_params[:foo] == "bar"
+        assert req.query_params[:abc] == "def"
+        assert req.post_params[:body] == "param"
         assert req.body == "body=param"
         {"localhost", _} = :cowboy_req.host(req.req)
         {202, [{"X-Custom", "My-Dynamic-Header"}], "Accepted"}


### PR DESCRIPTION
This PR lets you specify a function that returns a `{status, headers, body}` tuple which will be used for the reply.

This might be a little past the original intended use case for `http_server`, let me know! In the test, I don't think it's immediately obvious how this would be helpful: I'm just asserting that the request matches our HTTPotion call, which seems redundant. But it's useful if we want to verify that, behind a few levels of abstraction, we're forming our requests properly; for example, to verify that a request signature in the header is valid based on the body content.