### PR TITLE
Support range requests

### DIFF
--- a/lib/http_server/handler.ex
+++ b/lib/http_server/handler.ex
@@ -21,20 +21,67 @@ defmodule HttpServer.Handler do
   end
 
   def handle(req, state) do
+    {range_header, req} = :cowboy_req.header("range", req)
     {response, wait_time} = :ets.lookup(@ets_table, @ets_key)[@ets_key]
     wait_for(wait_time)
     case response do
       {status, headers, body} ->
+        {status, headers, body} = apply_byte_range({status, headers, body}, range_header)
         {:ok, req} = :cowboy_req.reply status, headers, body, req
       response ->
         if is_function(response) do
-          {status, headers, body} = response.(req_values(req))
+          {status, headers, body} =
+            response.(req_values(req))
+            |> apply_byte_range(range_header)
           {:ok, req} = :cowboy_req.reply status, headers, body, req
         else
-          {:ok, req} = :cowboy_req.reply 200, [], response, req
+          {status, headers, body} = apply_byte_range({200, [], response}, range_header)
+          {:ok, req} = :cowboy_req.reply status, headers, body, req
         end
     end
     {:ok, req, state}
+  end
+
+  defp normalize_byte_range(body, range_str) do
+    if range_str == :undefined do
+      nil
+    else
+      case parse_byte_range(range_str) do
+        nil -> nil
+        {:error, {:unexpected_range_header_format, _}} -> nil
+        {first, nil} ->
+          first..byte_size(body)
+        {first, last} ->
+          first..last
+      end
+    end
+  end
+
+  defp apply_byte_range({status, headers, body}, range_str) do
+    case normalize_byte_range(body, range_str) do
+      nil -> {status, headers, body}
+      first..last ->
+        new_body = Enum.slice(:erlang.binary_to_list(body), first..(last - 1)) |> :erlang.list_to_binary
+        new_headers = [{"Content-Range", "#{first}-#{last}"} | headers]
+        new_status = if status == 200, do: 206, else: status
+        {new_status, new_headers, new_body}
+    end
+  end
+
+  defp parse_byte_range(range_str) do
+    case Regex.run(~r/bytes=(\d+)-(\d*)/i, range_str) do
+      [_, first_str, last_str] ->
+        {first, _} = Integer.parse(first_str)
+        last =
+          if last_str == "" do
+            nil
+          else
+            {last, _} = Integer.parse(last_str)
+            last
+          end
+        {first, last}
+      nil -> {:error, {:unexpected_range_header_format, "expected \"Range: bytes=start-end\""}}
+    end
   end
 
   defp wait_for(duration) do


### PR DESCRIPTION
This PR adds support for automatically responding to byte range requests. I found this useful because I was testing with a tool that would make a request to an URL for the first 20 bytes, and if that looked valid, make a request for the whole file. http_server already has all the data required to respond to these, so I thought hey, why not?